### PR TITLE
ALCA

### DIFF
--- a/selfdrive/ui/bbui.h
+++ b/selfdrive/ui/bbui.h
@@ -764,7 +764,7 @@ void bb_ui_draw_UI( UIState *s) {
     tri_state_fd = open ("/sys/devices/virtual/switch/tri-state-key/state", O_RDONLY);
     //if we can't open then switch should be considered in the middle, nothing done
     if (tri_state_fd == -1) {
-      s->b.tri_state_switch = 2;
+      s->b.tri_state_switch = 1;
     } else {
       read (tri_state_fd, &buffer, 10);
       s->b.tri_state_switch = buffer[0] -48;


### PR DESCRIPTION
Using a EON gold which has not switch on bottom, this switch is normally needed to take advantage of the ALCA, in the EON Gold's case this had to be done in the code